### PR TITLE
Replace \e with \x1B in CliDumper to support colour in PHP < 5.4.

### DIFF
--- a/class/Patchwork/Dumper/Dumper/CliDumper.php
+++ b/class/Patchwork/Dumper/Dumper/CliDumper.php
@@ -279,14 +279,14 @@ class CliDumper extends AbstractDumper implements DumperInterface
             foreach ($cchr as $c) {
                 if (false !== strpos($val, $c)) {
                     $r = "\x7F" === $c ? '?' : chr(64 + ord($c));
-                    $r = "\e[{$this->styles[$style]};{$this->styles['cchr']}m{$r}\e[m";
-                    $r = "\e[m{$r}\e[{$this->styles[$style]}m";
+                    $r = "\x1B[{$this->styles[$style]};{$this->styles['cchr']}m{$r}\x1B[m";
+                    $r = "\x1B[m{$r}\x1B[{$this->styles[$style]}m";
                     $val = str_replace($c, $r, $val);
                 }
             }
         }
 
-        return sprintf("\e[%sm%s\e[m", $this->styles[$style], $val);
+        return sprintf("\x1B[%sm%s\x1B[m", $this->styles[$style], $val);
     }
 
     protected function supportsColors()


### PR DESCRIPTION
According to http://phpsadness.com/sad/20:

> In <5.4, PHP has no shorthand escape code for the Escape character; it is usually \e.

(I know, I should switch to 5.4. I will, soon.)
