### PR TITLE
Renamed the DebugExtension to be compatible with the Twig_Extension_Debug

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Twig/DebugExtension.php
+++ b/src/Symfony/Bundle/DebugBundle/Twig/DebugExtension.php
@@ -27,6 +27,6 @@ class DebugExtension extends \Twig_Extension
 
     public function getName()
     {
-        return 'debug';
+        return 'symfony_debug';
     }
 }


### PR DESCRIPTION
Twig does not allow registering 2 extensions with the same name (it replaces the previous one), and `debug` is already used by Twig_Extension_Debug in core
